### PR TITLE
changed to math.fmod

### DIFF
--- a/base64.lua
+++ b/base64.lua
@@ -45,10 +45,10 @@ function to_base64(to_encode)
 
     -- Check the number of bytes. If it's not evenly divisible by three,
     -- zero-pad the ending & append on the correct number of ``=``s.
-    if math.mod(string.len(bit_pattern), 3) == 2 then
+    if math.fmod(string.len(bit_pattern), 3) == 2 then
         trailing = '=='
         bit_pattern = bit_pattern .. '0000000000000000'
-    elseif math.mod(string.len(bit_pattern), 3) == 1 then
+    elseif math.fmod(string.len(bit_pattern), 3) == 1 then
         trailing = '='
         bit_pattern = bit_pattern .. '00000000'
     end


### PR DESCRIPTION
math.mod does not exist in both Lua 5.2.0 (on Linux) and Lua 5.3.4 (on OS/X).  same error message was observed.
~/Workspace/lua$ lua base64_test.lua
lua: ./base64.lua:48: attempt to call a nil value (field 'mod')
stack traceback:
	./base64.lua:48: in function 'to_base64'
	base64_test.lua:3: in main chunk
	[C]: in ?